### PR TITLE
Load gRPC methods whenever selecting a new request

### DIFF
--- a/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
@@ -1,6 +1,5 @@
-import React, { FunctionComponent, useRef, useState } from 'react';
+import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
 import { useParams, useRouteLoaderData } from 'react-router-dom';
-import { useMount } from 'react-use';
 import styled from 'styled-components';
 
 import { getCommonHeaderNames, getCommonHeaderValues } from '../../../common/common-headers';
@@ -78,14 +77,17 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
 
   const [isProtoModalOpen, setIsProtoModalOpen] = useState(false);
   const { requestMessages, running, methods } = grpcState;
-  useMount(async () => {
-    if (!activeRequest.protoFileId) {
-      return;
+  useEffect(() => {
+    async function loadMethods() {
+      if (!activeRequest.protoFileId || grpcState.methods.length > 0) {
+        return;
+      }
+      console.log(`[gRPC] loading proto file methods pf=${activeRequest.protoFileId}`);
+      const methods = await window.main.grpc.loadMethods(activeRequest.protoFileId);
+      setGrpcState({ ...grpcState, methods });
     }
-    console.log(`[gRPC] loading proto file methods pf=${activeRequest.protoFileId}`);
-    const methods = await window.main.grpc.loadMethods(activeRequest.protoFileId);
-    setGrpcState({ ...grpcState, methods });
-  });
+    loadMethods();
+  }, [activeRequest]);
   const editorRef = useRef<CodeEditorHandle>(null);
   const gitVersion = useGitVCSVersion();
   const activeRequestSyncVersion = useActiveRequestSyncVCSVersion();


### PR DESCRIPTION
Fixes #52 

After debugging this, it seems to me the issue was that the methods were **only** loaded for the request that happened to be selected at startup. This caused the method selection and request body to be broken for all other requests.

This PR changes request loading so that gRPC methods are loaded whenever the GrpcRequestPane is opened for a new gRPC request.

This whole loading of proto methods is pretty inefficient, it writes the proto file to temporary storage and re-parses it every time a request is selected. This could be improved by trivially adding a little cache in ipc/grpc that memoizes these results, but the downside is that users would then have to explicitly reload the protos every time they change.