### PR TITLE
Fix request URL being empty when switching between requests

### DIFF
--- a/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
@@ -248,7 +248,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
           style={{ display: 'none' }}
           readOnly={readOnly}
           autoComplete="off"
-          defaultValue=""
+          defaultValue={defaultValue}
         />
       </div>
     </div >


### PR DESCRIPTION
Noticed that when switching between requests, the request URL is cleared out every time. This PR restores the request URL after swithing between two requests