### PR TITLE
Replace grpc streaming response UI with a console-like message feed

### DIFF
--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -79,6 +79,7 @@ export interface CodeEditorProps {
   getAutocompleteConstants?: () => string[] | PromiseLike<string[]>;
   getAutocompleteSnippets?: () => CodeMirror.Snippet[];
   hideGutters?: boolean;
+  hideFilter?: boolean;
   hideLineNumbers?: boolean;
   hintOptions?: ShowHintOptions;
   id: string;
@@ -144,6 +145,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
   filterHistory,
   getAutocompleteConstants,
   getAutocompleteSnippets,
+  hideFilter,
   hideGutters,
   hideLineNumbers,
   hintOptions,
@@ -293,7 +295,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
       indentUnit: indentSize || TAB_SIZE,
       hintOptions,
       info: infoOptions,
-      viewportMargin: dynamicHeight ? Infinity : 30,
+      viewportMargin: 30,
       readOnly: !!readOnly,
       selectionPointer: 'default',
       jump: jumpOptions,
@@ -510,7 +512,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
     },
   }), []);
 
-  const showFilter = readOnly && (mode?.includes('json') || mode?.includes('xml'));
+  const showFilter = !hideFilter && readOnly && (mode?.includes('json') || mode?.includes('xml'));
   const showPrettify = showPrettifyButton && mode?.includes('json') || mode?.includes('xml');
 
   return (

--- a/packages/insomnia/src/ui/components/panes/grpc-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/grpc-response-pane.tsx
@@ -1,28 +1,35 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useEffect, useRef } from 'react';
 
-import { GrpcRequestState } from '../../routes/debug';
+import { GrpcMessage, GrpcRequestState } from '../../routes/debug';
 import { TabItem, Tabs } from '../base/tabs';
 import { CodeEditor } from '../codemirror/code-editor';
 import { GrpcStatusTag } from '../tags/grpc-status-tag';
 import { Pane, PaneBody, PaneHeader } from './pane';
+import { type GrpcMethodInfo } from '../../../main/ipc/grpc';
+import { Timestamp } from '../timestamp';
+
 interface Props {
   grpcState: GrpcRequestState;
 }
 
-export const GrpcResponsePane: FunctionComponent<Props> = ({ grpcState: { running, responseMessages, status, error } }) => {
+const GrpcPaneHeader: FunctionComponent<Props> = ({ grpcState }) => (
+  <PaneHeader className="row-spaced">
+    <div className="no-wrap scrollable scrollable--no-bars pad-left">
+      {grpcState.running && <i className='fa fa-refresh fa-spin margin-right-sm' />}
+      {grpcState.status && <GrpcStatusTag statusCode={grpcState.status.code} statusMessage={grpcState.status.details} />}
+      {!grpcState.status && grpcState.error && <GrpcStatusTag statusMessage={grpcState.error.message} />}
+    </div>
+  </PaneHeader>
+);
+
+const GrpcUnaryResponsePane: FunctionComponent<Props> = ({ grpcState }) => {
   return (
     <Pane type="response">
-      <PaneHeader className="row-spaced">
-        <div className="no-wrap scrollable scrollable--no-bars pad-left">
-          {running && <i className='fa fa-refresh fa-spin margin-right-sm' />}
-          {status && <GrpcStatusTag statusCode={status.code} statusMessage={status.details} />}
-          {!status && error && <GrpcStatusTag statusMessage={error.message} />}
-        </div>
-      </PaneHeader>
-      <PaneBody >
-        {responseMessages.length
+      <GrpcPaneHeader grpcState={grpcState} />
+      <PaneBody>
+        {grpcState.responseMessages.length
           ? (<Tabs aria-label="Grpc tabbed messages tabs" isNested>
-            {responseMessages.sort((a, b) => a.created - b.created).map((m, index) => (
+            {grpcState.responseMessages.map((m, index) => (
               <TabItem key={m.id} title={`Response ${index + 1}`}>
                 <CodeEditor
                   id="grpc-response"
@@ -40,3 +47,70 @@ export const GrpcResponsePane: FunctionComponent<Props> = ({ grpcState: { runnin
     </Pane>
   );
 };
+
+const TEXT_COLOR = "rgb(150 150 150)";
+const BG_COLOR = "rgb(34 34 34)";
+const BORDER_COLOR = "rgb(56 56 56)";
+
+const GrpcStreamingResponseHeader: FunctionComponent<{ message: GrpcMessage }> = ({ message }) => {
+  return (
+    <div
+      style={{
+        width: "100%",
+        backgroundColor: BG_COLOR,
+        borderBottom: `1px solid ${BORDER_COLOR}`,
+        padding: "0px 0px 3px 25px",
+        color: TEXT_COLOR,
+        fontStyle: "italic",
+        fontSize: "8pt",
+        paddingTop: "2px",
+      }}
+    >
+      Received at: <Timestamp time={message.created} />
+    </div>
+  );
+};
+
+const GrpcStreamingResponsePane: FunctionComponent<Props> = ({ grpcState }) => {
+  const messagesBottom = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    messagesBottom.current?.scrollIntoView();
+  });
+
+  return (
+    <Pane type="response">
+      <GrpcPaneHeader grpcState={grpcState} />
+      <PaneBody>
+        <div style={{ height: "100%", overflow:"scroll" }}>
+          {grpcState.responseMessages.map(m => (
+            <div key={m.id} style={{ borderBottom: `1px solid ${BORDER_COLOR}` }}>
+              <GrpcStreamingResponseHeader message={m} />
+              <CodeEditor
+                id="grpc-response"
+                defaultValue={m.text}
+                mode="application/json"
+                dynamicHeight
+                enableNunjucks
+                readOnly
+                hideFilter
+                autoPrettify
+              />
+            </div>))}
+            <div ref={messagesBottom} />
+        </div>
+
+      </PaneBody>
+    </Pane>
+  );
+};
+
+export const GrpcResponsePane: FunctionComponent<Props> = ({ grpcState }) => {
+  return grpcState.method && hasStreamingResponse(grpcState.method)
+    ? <GrpcStreamingResponsePane grpcState={grpcState} />
+    : <GrpcUnaryResponsePane grpcState={grpcState} />;
+};
+
+export function hasStreamingResponse(method: GrpcMethodInfo): boolean {
+  return method.type === "server" || method.type === "bidi";
+}

--- a/packages/insomnia/src/ui/components/timestamp.tsx
+++ b/packages/insomnia/src/ui/components/timestamp.tsx
@@ -1,0 +1,7 @@
+import React, { FunctionComponent } from 'react';
+import { format } from 'date-fns';
+
+export const Timestamp: FunctionComponent<{ time: Date | number }> = ({ time }) => {
+  const date = format(time, 'HH:mm:ss');
+  return <>{date}</>;
+};

--- a/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
@@ -1,5 +1,4 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { format } from 'date-fns';
 import React, { FC, useRef } from 'react';
 import { useMeasure } from 'react-use';
 import styled from 'styled-components';
@@ -7,11 +6,7 @@ import styled from 'styled-components';
 import { CurlEvent } from '../../../main/network/curl';
 import { WebSocketEvent } from '../../../main/network/websocket';
 import { SvgIcon, SvgIconProps } from '../svg-icon';
-
-const Timestamp: FC<{ time: Date | number }> = ({ time }) => {
-  const date = format(time, 'HH:mm:ss');
-  return <>{date}</>;
-};
+import { Timestamp } from '../timestamp';
 
 interface Props {
   events: (WebSocketEvent | CurlEvent)[];

--- a/packages/insomnia/src/ui/css/lib/codemirror/codemirror.css
+++ b/packages/insomnia/src/ui/css/lib/codemirror/codemirror.css
@@ -153,8 +153,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   overflow: scroll !important; /* Things will break if this is overridden */
   /* 30px is the magic margin used to hide the element's real scrollbars */
   /* See overflow: hidden in .CodeMirror */
-  margin-bottom: -30px; margin-right: -30px;
-  padding-bottom: 30px;
+  margin-bottom: -50px; margin-right: -30px;
   height: 100%;
   outline: none; /* Prevent dragging from highlighting the element */
   position: relative;

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -105,16 +105,16 @@ export interface GrpcRequestState {
   responseMessages: GrpcMessage[];
   status?: StatusObject;
   error?: ServiceError;
-  methods: GrpcMethodInfo[];
+  method?: GrpcMethodInfo;
 }
 
-const INITIAL_GRPC_REQUEST_STATE = {
+const INITIAL_GRPC_REQUEST_STATE: Omit<GrpcRequestState, "requestId"> = {
   running: false,
   requestMessages: [],
   responseMessages: [],
   status: undefined,
   error: undefined,
-  methods: [],
+  method: undefined,
 };
 export const loader: LoaderFunction = async ({ params }) => {
   if (!params.requestId) {


### PR DESCRIPTION
This PR replaces the gRPC streaming response pane for something that is more useful when testing. It also contains some small improvements to how the gRPC state is stored and loaded.

Old response pane:
![image](https://github.com/ArchGPT/insomnium/assets/7956873/f0892176-235e-4ca8-8fad-278437dc0d29)

New response pane:
![image](https://github.com/ArchGPT/insomnium/assets/7956873/cd353a54-5bc7-4125-a695-dd8c08aefcf9)
