### PR TITLE
Fix prompt being shown twice (#96)

### DIFF
--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -4,7 +4,7 @@ import { useFetcher, useParams, useRouteLoaderData } from 'react-router-dom';
 import { useInterval } from 'react-use';
 import styled from 'styled-components';
 
-import { RENDER_PURPOSE_SEND } from '../../common/render';
+import { RENDER_PURPOSE_NO_RENDER } from '../../common/render';
 import * as models from '../../models';
 import { isEventStreamRequest } from '../../models/request';
 import { fetchRequestData, tryToInterpolateRequest, tryToTransformRequestWithPlugins } from '../../network/network';
@@ -144,7 +144,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
       const { request,
         environment } = await fetchRequestData(requestId);
 
-      const renderResult = await tryToInterpolateRequest(request, environment._id, RENDER_PURPOSE_SEND);
+      const renderResult = await tryToInterpolateRequest(request, environment._id, RENDER_PURPOSE_NO_RENDER);
       // ARCHY NOTE: HERE IS SEND
       const renderedRequest = await tryToTransformRequestWithPlugins(renderResult);
       renderedRequest && send({


### PR DESCRIPTION
Reason (as I can see it):
The interpolation of the request params is done twice. Both interpolations were called using the context RENDER_PURPOSE_RENDER which triggers the prompt in `local-template-tags.ts`.
This file contains the "prompt" function as a plugin. `context.app.prompt` is called there without checking for the already set cached value when context === "send".

This "fix" renders the first time with renderPurpose set to "no-render" so no prompt is called in this case since no plugins (the "prompt") are called anyway.

This might have side effects I have not encountered so far!

Closes #96

ps. A version for mac (universal) that incorporates this fix is here: https://github.com/thenoseman/insomnium/releases/tag/fix-double-prompt-test-release


This is just for testing purposes and should **not be used** longterm!