### PR TITLE
Fix help text for timestamp format

### DIFF
--- a/packages/insomnia/src/ui/components/templating/local-template-tags.ts
+++ b/packages/insomnia/src/ui/components/templating/local-template-tags.ts
@@ -79,7 +79,7 @@ const localTemplatePlugins: { templateTag: PluginTemplateTag }[] = [
           ],
         },
         {
-          help: 'moment.js format string',
+          help: 'date-fns format string',
           displayName: 'Custom Format Template',
           type: 'string',
           placeholder: 'MMMM Do YYYY, h:mm:ss a',


### PR DESCRIPTION
Currently, the helptext says the format string should me in moment.js format, when it shouldn't. Insomni(um|a) uses date-fns.
