### PR TITLE
[#108] Submit issue instead of Contact Support

### DIFF
--- a/packages/insomnia/src/ui/components/viewers/response-error-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-error-viewer.tsx
@@ -51,13 +51,13 @@ export const ResponseErrorViewer: FC<Props> = memo(({ error }) => {
       <div className="text-center pad">
         <p className="faint pad-left pad-right">Here are some additional things that may help.</p>
         {msg}
-          &nbsp;&nbsp;
+        &nbsp;&nbsp;
         <Link
           button
           className="btn btn--clicky margin-top-sm"
-          href="https://insomnia.rest/support"
+          href="https://github.com/ArchGPT/insomnium#bugs-and-feature-requests"
         >
-          Contact Support
+          Submit an Issue
         </Link>
       </div>
     </div>


### PR DESCRIPTION
Closes https://github.com/ArchGPT/insomnium/issues/108

As @Fearvel pointed out, Insomnium shouldn't point users at Kong's support since they don't actually support it! Switching the button to read "Submit an Issue" and pointing it at [this part of the README](https://github.com/ArchGPT/insomnium#bugs-and-feature-requests)

Left the "Documentation" button alone. 
