### PR TITLE
Upgrade the version of package httpsnippet to 3.0.1

### DIFF
--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -67,7 +67,7 @@
     "hkdf": "^0.0.2",
     "hosted-git-info": "5.2.1",
     "html-entities": "^2.4.0",
-    "httpsnippet": "^2.0.0",
+    "httpsnippet": "^3.0.1",
     "iconv-lite": "^0.6.3",
     "isomorphic-git": "^1.10.4",
     "js-yaml": "^3.14.1",


### PR DESCRIPTION
Current version is a bit old, upgrade to the newest version to get some benefits, such as using new RestSharp syntax for C# (instead of deprecated syntax).

<!--
Please open an [Issue](https://github.com/ArchGPT/insomnium/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
