### PR TITLE
Implement request rename on double click (as promised)

### DIFF
--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -191,7 +191,7 @@ export const Debug: FC = () => {
   const patchRequest = useRequestSetter();
   const patchGroup = useRequestGroupPatcher();
 
-  const handleItemDoublClick = (itemDoc: Request | GrpcRequest | WebSocketRequest | RequestGroup) => {
+  const handleItemDoublClick = useCallback((itemDoc: Request | GrpcRequest | WebSocketRequest | RequestGroup) => {
     const isGroup = isRequestGroup(itemDoc);
 
     showPrompt({
@@ -202,7 +202,7 @@ export const Debug: FC = () => {
       label: 'Name',
       onComplete: name => (isGroup ? patchGroup : patchRequest)(itemDoc._id, { name }),
     });
-  }
+  }, [patchRequest, patchGroup]);
 
   useEffect(() => {
     db.onChange(async (changes: ChangeBufferEvent[]) => {

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -1,7 +1,7 @@
 import { IconName } from '@fortawesome/fontawesome-svg-core';
 import { ServiceError, StatusObject } from '@grpc/grpc-js';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import React, { FC, Fragment, useEffect, useRef, useState } from 'react';
+import React, { FC, Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import {
   Button,
   DropIndicator,
@@ -79,6 +79,7 @@ import {
   CreateRequestType,
   useRequestGroupMetaPatcher,
   useRequestMetaPatcher,
+  useRequestSetter,
 } from '../hooks/use-request';
 import {
   GrpcRequestLoaderData,
@@ -186,6 +187,8 @@ export const Debug: FC = () => {
   const [isEnvironmentModalOpen, setEnvironmentModalOpen] = useState(false);
 
   const patchRequestMeta = useRequestMetaPatcher();
+  const patchRequest = useRequestSetter();
+
   useEffect(() => {
     db.onChange(async (changes: ChangeBufferEvent[]) => {
       for (const change of changes) {
@@ -617,7 +620,7 @@ export const Debug: FC = () => {
   const virtualizer = useVirtualizer<HTMLDivElement | null, Child>({
     getScrollElement: () => parentRef.current,
     count: visibleCollection.length,
-    estimateSize: React.useCallback(() => 32, []),
+    estimateSize: useCallback(() => 32, []),
     overscan: 30,
     getItemKey: index => visibleCollection[index].doc._id,
   });
@@ -890,7 +893,21 @@ export const Debug: FC = () => {
                           gRPC
                         </span>
                       )}
-                      <span className="truncate">{getRequestNameOrFallback(item.doc)}</span>
+                      <span
+                        className="truncate"
+                        onDoubleClick={() => {
+                          showPrompt({
+                            title: 'Rename Request',
+                            defaultValue: item.doc.name,
+                            submitName: 'Rename',
+                            selectText: true,
+                            label: 'Name',
+                            onComplete: name => patchRequest(item.doc._id, { name }),
+                          });
+                        }}
+                      >
+                        {getRequestNameOrFallback(item.doc)}
+                      </span>
                       <span className="flex-1" />
                       {item.pinned && (
                         <Icon className='text-[--font-size-sm]' icon="thumb-tack" />
@@ -977,7 +994,21 @@ export const Debug: FC = () => {
                             icon={item.collapsed ? 'folder' : 'folder-open'}
                           />
                         )}
-                        <span className="truncate">{getRequestNameOrFallback(item.doc)}</span>
+                        <span
+                          className="truncate"
+                          onDoubleClick={() => {
+                            showPrompt({
+                              title: 'Rename Request',
+                              defaultValue: item.doc.name,
+                              submitName: 'Rename',
+                              selectText: true,
+                              label: 'Name',
+                              onComplete: name => patchRequest(item.doc._id, { name }),
+                            });
+                          }}
+                        >
+                          {getRequestNameOrFallback(item.doc)}
+                        </span>
                         <span className="flex-1" />
                         {isWebSocketRequest(item.doc) && <WebSocketSpinner requestId={item.doc._id} />}
                         {isEventStreamRequest(item.doc) && <EventStreamSpinner requestId={item.doc._id} />}

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -78,6 +78,7 @@ import { useReadyState } from '../hooks/use-ready-state';
 import {
   CreateRequestType,
   useRequestGroupMetaPatcher,
+  useRequestGroupPatcher,
   useRequestMetaPatcher,
   useRequestSetter,
 } from '../hooks/use-request';
@@ -188,6 +189,20 @@ export const Debug: FC = () => {
 
   const patchRequestMeta = useRequestMetaPatcher();
   const patchRequest = useRequestSetter();
+  const patchGroup = useRequestGroupPatcher();
+
+  const handleItemDoublClick = (itemDoc: Request | GrpcRequest | WebSocketRequest | RequestGroup) => {
+    const isGroup = isRequestGroup(itemDoc);
+
+    showPrompt({
+      title: isGroup ? 'Rename Folder' : 'Rename Request',
+      defaultValue: itemDoc.name,
+      submitName: 'Rename',
+      selectText: true,
+      label: 'Name',
+      onComplete: name => (isGroup ? patchGroup : patchRequest)(itemDoc._id, { name }),
+    });
+  }
 
   useEffect(() => {
     db.onChange(async (changes: ChangeBufferEvent[]) => {
@@ -895,16 +910,7 @@ export const Debug: FC = () => {
                       )}
                       <span
                         className="truncate"
-                        onDoubleClick={() => {
-                          showPrompt({
-                            title: 'Rename Request',
-                            defaultValue: item.doc.name,
-                            submitName: 'Rename',
-                            selectText: true,
-                            label: 'Name',
-                            onComplete: name => patchRequest(item.doc._id, { name }),
-                          });
-                        }}
+                        onDoubleClick={() => handleItemDoublClick(item.doc)}
                       >
                         {getRequestNameOrFallback(item.doc)}
                       </span>
@@ -996,16 +1002,7 @@ export const Debug: FC = () => {
                         )}
                         <span
                           className="truncate"
-                          onDoubleClick={() => {
-                            showPrompt({
-                              title: 'Rename Request',
-                              defaultValue: item.doc.name,
-                              submitName: 'Rename',
-                              selectText: true,
-                              label: 'Name',
-                              onComplete: name => patchRequest(item.doc._id, { name }),
-                            });
-                          }}
+                          onDoubleClick={() => handleItemDoublClick(item.doc)}
                         >
                           {getRequestNameOrFallback(item.doc)}
                         </span>


### PR DESCRIPTION
Request settings modal promises that request name change is also available in the sidebar by double click, but it either never worked this way or was lost at some point. 

<img width="794" alt="Screenshot 2024-01-29 at 21 26 30" src="https://github.com/ArchGPT/insomnium/assets/1522846/ca79d82e-8939-4316-aa27-4482b0fa19e5">


https://github.com/ArchGPT/insomnium/assets/1522846/1fb97de3-2c09-4583-9134-956d4a374f7b


