### PR TITLE
Add Request Settings Modal autofocus to ease up "add description" user journey

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
@@ -258,6 +258,7 @@ export const RequestActionsDropdown = ({
       <RequestSettingsModal
         request={request}
         onHide={() => setIsSettingsModalOpen(false)}
+        autoFocusOn="name"
       />
     )}
     </Fragment>

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -342,6 +342,7 @@ export const RequestPane: FC<Props> = ({
         <RequestSettingsModal
           request={activeRequest}
           onHide={() => setIsRequestSettingsModalOpen(false)}
+          autoFocusOn="description"
         />
       )}
     </Pane>

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -401,6 +401,7 @@ export const WebSocketRequestPane: FC<Props> = ({ environment }) => {
         <RequestSettingsModal
           request={activeRequest}
           onHide={() => setIsRequestSettingsModalOpen(false)}
+          autoFocusOn="description"
         />
       )}
     </Pane>

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -1059,6 +1059,7 @@ export const Debug: FC = () => {
               <RequestSettingsModal
                 request={activeRequest}
                 onHide={() => setIsRequestSettingsModalOpen(false)}
+                autoFocusOn="name"
               />
             )}
           </ErrorBoundary>


### PR DESCRIPTION
Saves users a few clicks, especially useful when adding descriptions in a batch.

https://github.com/ArchGPT/insomnium/assets/1522846/a843a578-094f-4374-ab4b-5da3c5878c56

