### PR TITLE
Accessibility: Backport modal autofocus in latest insomnia version

### DIFF
--- a/packages/insomnia/src/ui/components/base/modal.tsx
+++ b/packages/insomnia/src/ui/components/base/modal.tsx
@@ -1,5 +1,6 @@
 import classnames from 'classnames';
 import React, { forwardRef, ReactNode, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import { FocusScope } from 'react-aria';
 
 import { createKeybindingsHandler } from '../keydown-binder';
 // Keep global z-index reference so that every modal will
@@ -93,22 +94,24 @@ export const Modal = forwardRef<ModalHandle, ModalProps>(({
   }, [handleKeydown]);
 
   return (open ?
-    <div
-      ref={containerRef}
-      onKeyDown={handleKeydown}
-      tabIndex={-1}
-      className={classes}
-      style={{ zIndex }}
-      aria-hidden={false}
-      role="dialog"
-    >
-      <div className="modal__backdrop overlay theme--transparent-overlay" data-close-modal />
-      <div className={classnames('modal__content__wrapper', { 'modal--centered': centered })}>
-        <div className="modal__content">
-          {children}
+    <FocusScope autoFocus>
+      <div
+        ref={containerRef}
+        onKeyDown={handleKeydown}
+        tabIndex={-1}
+        className={classes}
+        style={{ zIndex }}
+        aria-hidden={false}
+        role="dialog"
+      >
+        <div className="modal__backdrop overlay theme--transparent-overlay" data-close-modal />
+        <div className={classnames('modal__content__wrapper', { 'modal--centered': centered })}>
+          <div className="modal__content">
+            {children}
+          </div>
         </div>
       </div>
-    </div>
+    </FocusScope>
     : null
   );
 });


### PR DESCRIPTION
This pull request backports [Pull request 6945](https://github.com/kong/insomnia/pull/6945) on Insomnia. This pull request adds a focus scope to the modals and autofocuses it, making a screen reader (for example NVDA) moving the cursor inside of the modal and speaking its contents automatically, instead of requiring the user to guess if the modal was opened and manually moving the keyboard to it.

Tests performed:

With the code on the main branch:

* With NVDA active, opened insomnium and pressed CTRL+, to open the preferences window.
NVDA does not identified the modal, requiring the user to press CTRL+HOME and space to open id, the arrow keys caused NVDA to speak other elements not related with the modal.

With the code on this pull request:
* With NVDA active, opened Insomnium and pressed CTRL+, to open the preferences window.
NVDA instantly started to speak the modal contents and the arrow keys worked to speak the modal elements.